### PR TITLE
Improve list search usability

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -142,6 +142,9 @@ body {
 
 .search-box {
   margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .search-input {
@@ -149,6 +152,10 @@ body {
   padding: 8px 12px;
   border: 1px solid #ddd;
   border-radius: 4px;
+}
+
+.search-button {
+  padding: 8px 16px;
 }
 
 .pagination {

--- a/frontend/src/views/ChengyuList.vue
+++ b/frontend/src/views/ChengyuList.vue
@@ -10,8 +10,16 @@
           type="text" 
           class="search-input"
           placeholder="搜索成语..."
-          @input="handleSearch"
+          @keyup.enter="handleSearch"
         >
+        <button 
+          class="btn btn-primary search-button" 
+          type="button"
+          @click="handleSearch"
+          :disabled="loading"
+        >
+          搜索
+        </button>
       </div>
       
       <table class="table" v-if="!loading && chengyuList.length > 0">
@@ -103,8 +111,9 @@ export default {
           size: pageSize.value
         }
         
-        if (searchQuery.value) {
-          params.search = searchQuery.value
+        const searchValue = searchQuery.value.trim()
+        if (searchValue) {
+          params.search = searchValue
         }
         
         const response = await request.get('/v1/chengyu', { params })

--- a/frontend/src/views/CiyuList.vue
+++ b/frontend/src/views/CiyuList.vue
@@ -10,8 +10,16 @@
           type="text" 
           class="search-input"
           placeholder="搜索词语..."
-          @input="handleSearch"
+          @keyup.enter="handleSearch"
         >
+        <button 
+          class="btn btn-primary search-button" 
+          type="button"
+          @click="handleSearch"
+          :disabled="loading"
+        >
+          搜索
+        </button>
       </div>
       
       <table class="table" v-if="!loading && ciyuList.length > 0">
@@ -105,8 +113,9 @@ export default {
           size: pageSize.value
         }
         
-        if (searchQuery.value) {
-          params.search = searchQuery.value
+        const searchValue = searchQuery.value.trim()
+        if (searchValue) {
+          params.search = searchValue
         }
         
         const response = await request.get('/v2/ciyu', { params })


### PR DESCRIPTION
## Summary
- add explicit search triggers to the Chengyu and Ciyu lists so users can search via button or Enter key
- trim search input values before sending requests to avoid whitespace-only queries
- adjust search box layout styling to accommodate the new controls

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469387282c8332855281726257f6f4)